### PR TITLE
Fix/crash on missing repository tag

### DIFF
--- a/src/Resolvers/VcsDetailsResolver.php
+++ b/src/Resolvers/VcsDetailsResolver.php
@@ -11,7 +11,7 @@ class VcsDetailsResolver
      * @var \Vaimo\ComposerChangelogs\Utils\SystemUtils
      */
     private $systemUtils;
-    
+
     /**
      * @var \Vaimo\ComposerChangelogs\Utils\PathUtils
      */
@@ -61,16 +61,16 @@ class VcsDetailsResolver
 
             $result = $this->systemUtils->getCommandStdOut($command, $repositoryRoot, '0');
         }
-        
+
         return trim($result);
     }
-    
+
     public function resolveReleaseLinks($repositoryUrl, $version, $lastVersion = '')
     {
         if (!$repositoryUrl) {
             return array();
         }
-        
+
         $urlComponents = parse_url($repositoryUrl);
 
         if (!isset($urlComponents['host'])) {
@@ -82,7 +82,7 @@ class VcsDetailsResolver
         if (!isset($this->linkTemplates[$hostCode])) {
             return array();
         }
-        
+
         $data = array();
 
         foreach ($this->linkTemplates[$hostCode] as $code => $template) {
@@ -95,22 +95,26 @@ class VcsDetailsResolver
 
         return $data;
     }
-    
+
     public function resolveReleaseTime($repositoryRoot, $version)
     {
         if (!$repositoryRoot) {
             return array();
         }
-        
+
         foreach ($this->dateQueryTemplates as $folder => $commandTemplate) {
             if (!file_exists($this->pathUtils->composePath($repositoryRoot, $folder))) {
                 continue;
             }
 
-            $result = $this->systemUtils->getCommandStdOut(
-                str_replace('{version}', $version, $commandTemplate),
-                $repositoryRoot
-            );
+            try {
+                $result = $this->systemUtils->getCommandStdOut(
+                    str_replace('{version}', $version, $commandTemplate),
+                    $repositoryRoot
+                );
+            } catch (\Exception $exception) {
+                return array();
+            }
 
             if (!$result) {
                 return array();
@@ -123,7 +127,7 @@ class VcsDetailsResolver
                 'time' => array_shift($segments)
             );
         }
-        
+
         return array();
     }
 }


### PR DESCRIPTION
Have had it happen with couple of modules using this, that if the repository happens to lose the tag listed in changelog.json, then the date resolving here in the updated class will fail and causes:

> 15:34:43  + composer changelog:generate --url=xxxxxxxxx
15:34:43  Generating changelog output for xxxxxxxxx
15:34:43  
15:34:43                                
15:34:43    [ErrorException]            
15:34:43    Array to string conversion  
15:34:43                                
15:34:43  
15:34:43  changelog:generate [--from-source] [--url [URL]] [--] [<name>]

Most commonly we have seen that some modules use "DEV." prefix in the tag and these seem to be now all have gone missing, which then causes the error. There are some other cases too, there has been also an actual version tag that's gone missing. 

Quick fix for these issues is usually updating the changelog.json to either drop the tag entirely or move the contents under it to another tag that does exist in the repository. But it's still frustrating to encounter when for example build process creates a new tag in the repository, but the logic here doesn't recognise it due to the run order etc and then causes the build to fail. So I've found it easiest to just suppress the error since the only downside is the lack of one or two dates in the generated changelog file. Wasn't able to figure out any other solution myself but any suggestions are of course welcome.