### PR TITLE
Added support for PHP 8.4

### DIFF
--- a/src/Console/OutputGenerator.php
+++ b/src/Console/OutputGenerator.php
@@ -18,7 +18,7 @@ class OutputGenerator
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      */
     public function __construct(
-        \Symfony\Component\Console\Output\OutputInterface $output = null
+        ?\Symfony\Component\Console\Output\OutputInterface $output = null
     ) {
         $this->output = $output;
     }

--- a/src/Factories/ChangelogRepositoryFactory.php
+++ b/src/Factories/ChangelogRepositoryFactory.php
@@ -23,7 +23,7 @@ class ChangelogRepositoryFactory
      */
     public function __construct(
         \Vaimo\ComposerChangelogs\Composer\Context $composerCtx,
-        \Symfony\Component\Console\Output\OutputInterface $output = null
+        ?\Symfony\Component\Console\Output\OutputInterface $output = null
     ) {
         $this->composerCtx = $composerCtx;
         $this->output = $output;

--- a/src/Loaders/TemplateLoader.php
+++ b/src/Loaders/TemplateLoader.php
@@ -18,7 +18,7 @@ class TemplateLoader implements \Mustache_Loader
     private $pathResolver;
 
     public function __construct(
-        \Closure $pathResolver = null
+        ?\Closure $pathResolver = null
     ) {
         $this->pathResolver = $pathResolver;
     }


### PR DESCRIPTION
Fixed issues related to https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated in the package in manner compatible with PHP 7.1 and higher