### PR TITLE
BOBCATM2-1225 fix: update console command execute() method signatures…

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -4,6 +4,11 @@
         "possible to generate change-logs in other formats as well (when needed) and to do automatic releases based on",
         "added change-log records. More on how to use it: https://github.com/vaimo/composer-changelogs"
     ],
+    "1.0.4": {
+        "fix": [
+            "Magento 2.4.9 compatibility fix: console command execute() method signature changed in Magento 2.4.9"
+        ]
+    },
     "1.0.3": {
         "fix": [
             "Fixed changelog:bootstrap command not working as expected"

--- a/src/Commands/BootstrapCommand.php
+++ b/src/Commands/BootstrapCommand.php
@@ -38,7 +38,7 @@ class BootstrapCommand extends \Composer\Command\BaseCommand
         );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $packageName = $input->getArgument('name');
         $format = $input->getOption('format');
@@ -47,7 +47,7 @@ class BootstrapCommand extends \Composer\Command\BaseCommand
         $composerCtx = $composerCtxFactory->create();
 
         $commandCtx = new \Vaimo\ComposerChangelogs\Console\Command\ExecutionContext($output, $composerCtx);
-        
+
         $cfgResolverFactory = new \Vaimo\ComposerChangelogs\Factories\Changelog\ConfigResolverFactory($composerCtx);
         $cfgResolver = $cfgResolverFactory->create();
 
@@ -62,7 +62,7 @@ class BootstrapCommand extends \Composer\Command\BaseCommand
         $output->writeln(
             sprintf('Bootstrapping changelog generation for <info>%s</info>', $package->getName())
         );
-        
+
         if ($cfgResolver->hasConfig($package)) {
             $rootPath = array(ComposerConfig::CONFIG_ROOT, PluginConfig::ROOT);
 
@@ -70,23 +70,23 @@ class BootstrapCommand extends \Composer\Command\BaseCommand
                 'Configuration root (<comment>%s</comment>) already present in package config',
                 implode('/', $rootPath)
             );
-            
+
             $output->writeln($message);
-            
+
             return 0;
         }
-        
+
         try {
             $packageManager->bootstrapChangelogGeneration($package, $format);
         } catch (\Vaimo\ComposerChangelogs\Exceptions\UpdaterException $exception) {
             $message = sprintf('<error>%s</error>', $exception->getMessage());
             $output->writeln($message);
-            
+
             return 1;
         }
-        
+
         $output->writeln('<info>Done</info>');
-        
+
         return 0;
     }
 }

--- a/src/Commands/GenerateCommand.php
+++ b/src/Commands/GenerateCommand.php
@@ -40,10 +40,10 @@ class GenerateCommand extends \Composer\Command\BaseCommand
         );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $packageName = $input->getArgument('name');
-        
+
         $fromSource = $input->getOption('from-source');
         $repositoryUrl = $input->getOption('url');
 
@@ -54,7 +54,7 @@ class GenerateCommand extends \Composer\Command\BaseCommand
         );
 
         $composerCtx = $composerCtxFactory->create();
-        
+
         $chLogRepoFactory = new Factories\ChangelogRepositoryFactory($composerCtx, $output);
         $chLogRepo = $chLogRepoFactory->create($fromSource);
 
@@ -72,7 +72,7 @@ class GenerateCommand extends \Composer\Command\BaseCommand
         $confResolver = $confResolverFactory->create($fromSource);
 
         $package = $changelog->getOwner();
-        
+
         $output->writeln(
             sprintf('Generating changelog output for <info>%s</info>', $package->getName())
         );
@@ -84,7 +84,7 @@ class GenerateCommand extends \Composer\Command\BaseCommand
         $featureFlags = $confResolver->getFeatureFlags($package);
 
         $urlResolver = $this->createUrlResolver($repositoryUrl, $featureFlags);
-        
+
         $docsGenerator = new \Vaimo\ComposerChangelogs\Generators\DocumentationGenerator(
             $confResolver,
             $infoResolver,
@@ -102,10 +102,10 @@ class GenerateCommand extends \Composer\Command\BaseCommand
         }
 
         $output->writeln('<info>Done</info>');
-        
+
         return 0;
     }
-    
+
     private function createUrlResolver($repositoryUrl, array $featureFlags)
     {
         if ($repositoryUrl !== null || !$featureFlags['links']) {
@@ -113,7 +113,7 @@ class GenerateCommand extends \Composer\Command\BaseCommand
         }
 
         $composerRuntime = $this->getComposer();
-        
+
         $infoResolver = new Resolvers\PackageInfoResolver(
             $composerRuntime->getInstallationManager()
         );

--- a/src/Commands/InfoCommand.php
+++ b/src/Commands/InfoCommand.php
@@ -77,7 +77,7 @@ class InfoCommand extends \Composer\Command\BaseCommand
         );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $packageName = $input->getArgument('name');
 
@@ -91,12 +91,12 @@ class InfoCommand extends \Composer\Command\BaseCommand
         $composerCtxFactory = new \Vaimo\ComposerChangelogs\Factories\ComposerContextFactory(
             $this->getComposer()
         );
-        
+
         $composerCtx = $composerCtxFactory->create();
 
         $chLogRepoFactory = new Factories\ChangelogRepositoryFactory($composerCtx, $output);
         $chLogRepo = $chLogRepoFactory->create($fromSource);
-        
+
         $changelog = $chLogRepo->getByPackageName(
             $packageName,
             $output->getVerbosity()
@@ -107,7 +107,7 @@ class InfoCommand extends \Composer\Command\BaseCommand
         }
 
         $releases = $changelog->getReleases();
-        
+
         if (!$version) {
             $version = $this->resolveVersion($releases, $branch, $showUpcoming);
         }
@@ -184,13 +184,13 @@ class InfoCommand extends \Composer\Command\BaseCommand
         if ($format === 'json') {
             return json_encode($groups, JSON_PRETTY_PRINT);
         }
-        
+
         $confResolverFactory = new Factories\Changelog\ConfigResolverFactory($composerCtx);
 
         $confResolver = $confResolverFactory->create($fromSource);
 
         $templateResolver = new \Vaimo\ComposerChangelogs\Resolvers\ChangelogTemplateResolver($confResolver);
-        
+
         $templates = $templateResolver->getTemplates($package);
 
         $renderCtxGenerator = new \Vaimo\ComposerChangelogs\Generators\Changelog\RenderContextGenerator();
@@ -199,9 +199,9 @@ class InfoCommand extends \Composer\Command\BaseCommand
         $infoResolver = new Resolvers\PackageInfoResolver(
             $composerRuntime->getInstallationManager()
         );
-        
+
         $repositoryRoot = $infoResolver->getInstallPath($package);
-        
+
         $ctxData = $renderCtxGenerator->generate(
             array('' => $groups),
             '',
@@ -221,7 +221,7 @@ class InfoCommand extends \Composer\Command\BaseCommand
             array('root' => $templates[$format]['release'])
         );
     }
-    
+
     private function resolveVersion($changelog, $branch, $showUpcoming)
     {
         $releaseResolver = new \Vaimo\ComposerChangelogs\Resolvers\ChangelogReleaseResolver();

--- a/src/Commands/ValidateCommand.php
+++ b/src/Commands/ValidateCommand.php
@@ -32,7 +32,7 @@ class ValidateCommand extends \Composer\Command\BaseCommand
         );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $packageName = $input->getArgument('name');
         $fromSource = $input->getOption('from-source');
@@ -42,7 +42,7 @@ class ValidateCommand extends \Composer\Command\BaseCommand
         );
 
         $composerCtx = $composerCtxFactory->create();
-        
+
         $chLogRepoFactory = new Factories\ChangelogRepositoryFactory($composerCtx, $output);
         $chLogRepo = $chLogRepoFactory->create($fromSource);
 
@@ -50,7 +50,7 @@ class ValidateCommand extends \Composer\Command\BaseCommand
             $packageName,
             $output->getVerbosity()
         );
-        
+
         return (int)($changelog === null);
     }
 }

--- a/src/Commands/VersionCommand.php
+++ b/src/Commands/VersionCommand.php
@@ -46,7 +46,7 @@ class VersionCommand extends \Composer\Command\BaseCommand
             \Symfony\Component\Console\Input\InputOption::VALUE_OPTIONAL,
             'Number of segments of the version to return. <comment>[default: all segments]</comment>'
         );
-        
+
         $this->addOption(
             '--upcoming',
             null,
@@ -69,7 +69,7 @@ class VersionCommand extends \Composer\Command\BaseCommand
         );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $packageName = $input->getArgument('name');
         $fromSource = $input->getOption('from-source');
@@ -85,12 +85,12 @@ class VersionCommand extends \Composer\Command\BaseCommand
         );
 
         $composerCtx = $composerCtxFactory->create();
-        
+
         $chLogRepoFactory = new Factories\ChangelogRepositoryFactory(
             $composerCtx,
             $output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL ? $output : null
         );
-        
+
         $chLogRepo = $chLogRepoFactory->create($fromSource);
 
         $changelog = $chLogRepo->getByPackageName($packageName);
@@ -100,7 +100,7 @@ class VersionCommand extends \Composer\Command\BaseCommand
         }
 
         $releases = $changelog->getReleases();
-        
+
         $releaseResolver = new \Vaimo\ComposerChangelogs\Resolvers\ChangelogReleaseResolver();
 
         $version = key($releases);
@@ -120,11 +120,11 @@ class VersionCommand extends \Composer\Command\BaseCommand
         $versionResolver = new \Vaimo\ComposerChangelogs\Resolvers\VersionResolver();
 
         $version = $versionResolver->resolveValidVersion($version);
-            
+
         if ($format === 'regex') {
             $version = preg_quote($version, '/');
         }
-        
+
         if ($segmentsCount) {
             $version = implode(
                 '.',
@@ -135,9 +135,9 @@ class VersionCommand extends \Composer\Command\BaseCommand
                 )
             );
         }
-        
+
         $output->writeln($version);
-        
+
         return 0;
     }
 }


### PR DESCRIPTION
This pull request updates the command classes for compatibility with Magento 2.4.9 and improves type safety by updating method signatures.

**Codebase Updates for Compatibility and Type Safety:**

* Updated the `execute()` method signature in the following command classes to return `int`, as required by Magento 2.4.9:
  - `BootstrapCommand` (`src/Commands/BootstrapCommand.php`)
  - `GenerateCommand` (`src/Commands/GenerateCommand.php`)
  - `InfoCommand` (`src/Commands/InfoCommand.php`)
  - `ValidateCommand` (`src/Commands/ValidateCommand.php`)
  - `VersionCommand` (`src/Commands/VersionCommand.php`)

These changes ensure the package remains compatible with the latest Magento release and adheres to the updated interface requirements.
The changes are backward compatible, it works fine on old Magento versions where is a signature doesn't have return type:
```
protected function execute(InputInterface $input, OutputInterface $output)
```